### PR TITLE
Implement task 4-8

### DIFF
--- a/lib/mocks.dart
+++ b/lib/mocks.dart
@@ -2,7 +2,7 @@ import 'package:places/domain/sight.dart';
 
 final List<Sight> mocks = [
   Sight(
-    'Acueducto de Segovia',
+    'Acueducto de Segovia Acueducto de Segovia Acueducto de Segovia',
     40.94800736932299,
     -4.117791526511193,
     'https://upload.wikimedia.org/wikipedia/commons/c/c9/Acueducto_Romano_%28Segovia%2C_España%29.jpg',
@@ -18,7 +18,7 @@ final List<Sight> mocks = [
     'Medieval complex housing palaces, carved Moorish throne room & cloistered courtyards with fountains',
   ),
   Sight(
-    'La Ciudad de las Artes y las Ciencias',
+    'La Ciudad de las Artes y las Ciencias La Ciudad de las Artes y las Ciencias',
     39.45493273656893,
     -0.3504675224226168,
     'https://upload.wikimedia.org/wikipedia/commons/e/ef/La_Ciudad_de_las_Artes_y_las_Ciencias_de_Valencia.jpg',
@@ -26,7 +26,7 @@ final List<Sight> mocks = [
     'Сomplejo arquitectónico, cultural y de entretenimiento',
   ),
   Sight(
-    'Edinburgh Castle',
+    'Edinburgh Castle Edinburgh Castle Edinburgh Castle Edinburgh Castle',
     55.948684005579224,
     -3.2000529055591183,
     'https://upload.wikimedia.org/wikipedia/commons/a/a1/EdinburghCastle.jpg',
@@ -34,7 +34,7 @@ final List<Sight> mocks = [
     'Castle',
   ),
   Sight(
-    'National Monument of Scotland',
+    'National Monument of Scotland National Monument of Scotland',
     55.95477100772063,
     -3.181899383180622,
     'https://upload.wikimedia.org/wikipedia/commons/0/0e/National_Monument_of_Scotland%2C_Calton_Hill%2C_Edinburgh.jpg',
@@ -42,7 +42,7 @@ final List<Sight> mocks = [
     'Tourist attraction',
   ),
   Sight(
-    'Dean Village',
+    'Dean Village Dean Village Dean Village Dean Village Dean Village',
     55.9523381383206,
     -3.218433886612059,
     'https://upload.wikimedia.org/wikipedia/commons/a/a4/Dean_Village%2C_Edinburgh_%2837952869852%29.jpg',

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -16,10 +16,10 @@ class SightCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: double.infinity,
-      //I've put here height 188 because the two halves of each SightCard has height of 96 and 92 in Figma.
-      height: 188,
+    return
+        // 4.8.3 AspectRatio используйте, чтобы привести виджеты SightCard в соотношение 3/2
+        AspectRatio(
+      aspectRatio: 3 / 2,
       child: ClipRRect(
         borderRadius: BorderRadius.circular(12),
         child: ColoredBox(
@@ -29,36 +29,54 @@ class SightCard extends StatelessWidget {
             children: [
               Column(
                 children: [
-                  SizedBox(
-                    width: double.infinity,
-                    height: 96,
-                    child: Image.network(
-                      sight.url,
-                      fit: BoxFit.cover,
+                  // The first section with the photo of the sight
+                  Flexible(
+                    flex: 96,
+                    child: Container(
+                      width: double.infinity,
+                      child: Image.network(
+                        sight.url,
+                        fit: BoxFit.cover,
+                      ),
                     ),
                   ),
-                  SizedBox(
-                    width: double.infinity,
-                    height: 92,
+                  // The second section with the name and description of the sight
+                  Flexible(
+                    flex: 92,
                     child: Padding(
-                      padding: const EdgeInsets.all(16.0),
+                      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text(
-                            sight.name,
-                            textAlign: TextAlign.left,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
-                              fontWeight: FontWeight.w500,
-                              fontSize: 16,
-                              //In Figma 'Line height' = 20px.
-                              // To achieve this I use height of 1.25 => fontSize = 16 * 1.25 gives 20
-                              height: 1.25,
-                              color: Color(AppColors.appSecondaryColor),
+                          // 4.8.2 Добавьте отступ между между фотографиями и описанием с помощью SizedBox
+                          const SizedBox(
+                            height: 16,
+                          ),
+                          // The name of the sight
+                          // 4.8.1  Используйте ConstrainedBox, чтобы ограничить размер текста по ширине до половины размера карточки.
+                          ConstrainedBox(
+                            constraints: BoxConstraints(
+                              maxWidth: MediaQuery.of(context).size.width / 2,
+                            ),
+                            child: Text(
+                              sight.name,
+                              textAlign: TextAlign.left,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                fontWeight: FontWeight.w500,
+                                fontSize: 16,
+                                //In Figma 'Line height' = 20px.
+                                // To achieve this I use height of 1.25 => fontSize = 16 * 1.25 gives 20
+                                height: 1.25,
+                                color: Color(AppColors.appSecondaryColor),
+                              ),
                             ),
                           ),
+                          const SizedBox(
+                            height: 2,
+                          ),
+                          // The sight details
                           Text(
                             sight.details,
                             textAlign: TextAlign.left,
@@ -79,6 +97,7 @@ class SightCard extends StatelessWidget {
                   ),
                 ],
               ),
+              // The type of the sight in the left upper corner of the sight card.
               Align(
                 alignment: Alignment.topLeft,
                 child: Padding(

--- a/lib/ui/screen/sight_list_screen.dart
+++ b/lib/ui/screen/sight_list_screen.dart
@@ -18,39 +18,47 @@ class _SightListScreenState extends State<SightListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        //toolbarHeight: 112,
-        toolbarHeight: 128,
-        elevation: 0,
-        title: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: const [
-            SizedBox(
-              width: double.infinity,
-              height: 40,
-            ),
-            Text(
-              AppStrings.appBarText,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                fontFamily: 'Roboto',
-                fontWeight: FontWeight.w700,
-                fontSize: 32,
-                //In Figma 'Line height' = 36px.
-                // To achieve this I use height of 1.125 => fontSize = 32 * 1.125 gives 36
-                height: 1.125,
-                color: Color(AppColors.appSecondaryColor),
-              ),
-            ),
-            SizedBox(
-              width: double.infinity,
-              height: 16,
-            ),
-          ],
-        ),
+      appBar: const MyCustomAppBar(
+        // Here the height is 128px = 16px of bottomPadding + 72px of Text + 40px of topPadding
+        // In the MyCustomAppBar there is a SafeArea widget, which is 24px high in the design but can be different.
+        height: 128,
       ),
+
+      // The previous version of the AppBar
+      // AppBar(
+      //   backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      //   //toolbarHeight: 112,
+      //   toolbarHeight: 112,
+      //   elevation: 0,
+      //   title: Column(
+      //     crossAxisAlignment: CrossAxisAlignment.start,
+      //     children: const [
+      //       SizedBox(
+      //         width: double.infinity,
+      //         height: 20,
+      //       ),
+      //       Text(
+      //         AppStrings.appBarText,
+      //         maxLines: 2,
+      //         overflow: TextOverflow.ellipsis,
+      //         style: TextStyle(
+      //           fontFamily: 'Roboto',
+      //           fontWeight: FontWeight.w700,
+      //           fontSize: 32,
+      //           //In Figma 'Line height' = 36px.
+      //           // To achieve this I use height of 1.125 => fontSize = 32 * 1.125 gives 36
+      //           height: 1.125,
+      //           color: Color(AppColors.appSecondaryColor),
+      //         ),
+      //       ),
+      //       SizedBox(
+      //         width: double.infinity,
+      //         height: 16,
+      //       ),
+      //     ],
+      //   ),
+      // ),
+
       body: SingleChildScrollView(
         child: Column(
           children: [
@@ -85,4 +93,45 @@ class _SightListScreenState extends State<SightListScreen> {
       ),
     );
   }
+}
+
+// 4.8.4 Переверстать AppBar через наследника PreferredSizeWidget.
+class MyCustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final double height;
+
+  const MyCustomAppBar({super.key, required this.height});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        children: const [
+          SizedBox(
+            width: double.infinity,
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(16, 40, 16, 16),
+              child: Text(
+                AppStrings.appBarText,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                textScaleFactor: 1.0,
+                style: TextStyle(
+                  fontFamily: 'Roboto',
+                  fontWeight: FontWeight.w700,
+                  fontSize: 32,
+                  //In Figma 'Line height' = 36px.
+                  // To achieve this I use height of 1.125 => fontSize = 32 * 1.125 gives 36
+                  height: 1.125,
+                  color: Color(AppColors.appSecondaryColor),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(height);
 }


### PR DESCRIPTION
Для удобства в коде есть следующие комментарии о соответствующих частях задания:
// 4.8.1  Используйте ConstrainedBox, чтобы ограничить размер текста по ширине до половины размера карточки.
// 4.8.2 Добавьте отступ между между фотографиями и описанием с помощью SizedBox
// 4.8.3 AspectRatio используйте, чтобы привести виджеты SightCard в соотношение 3/2
// 4.8.4 Переверстать AppBar через наследника PreferredSizeWidget. 

Вопрос: 
1) В виджете SightCard используйте ConstrainedBox, чтобы ограничить размер текста  по ширине до половины размера карточки. 
Посмотрите на результат. 
Почему размер виджета Text поменялся?

Ответ:
Выставил maxWidth = MediaQuery.of(context).size.width / 2 в constraints у ConstrainedBox.
Поскольку ConstrainedBox imposes additional constraints from those it receives from its parent, этот виджет берёт ширину экрана и выставляет своему ребёнку (Text()) требование быть максимум в пол экрана в ширину. При этом ребёнок говорит, что хочет быть равным длинне строки текста внутри. В итоге ребёнок принимает ширину строки текста внутри, но не больше половины экрана. Тот самый принцип Constraints go down. Sizes go up. 

Вот скриншот для примера:
<img src="https://user-images.githubusercontent.com/17640079/191344115-d7217ddb-488c-4c3f-9f6e-dc47ebaa4a20.jpeg" width=50% height=50%>
